### PR TITLE
Update date format

### DIFF
--- a/components/Entry/index.tsx
+++ b/components/Entry/index.tsx
@@ -5,6 +5,7 @@ import { Button, Tag } from '@moai/core';
 import { HiOutlineExternalLink as externalLink } from 'react-icons/hi';
 import { getHostName } from '../../utils/url';
 import { excerpt, minimum as minimumStringLength } from '../../utils/string';
+import { formatDate } from '../../utils/date';
 import { RoundedPanel } from '../RoundedPane';
 import styles from './Entry.module.css';
 
@@ -26,7 +27,7 @@ export const Entry = ({ doc }) => {
       <h3 className="entry-title">
         <a href={`/read?url=${encodeURIComponent(doc.link)}`}>{doc.title}</a>
       </h3>
-      <p>Đăng ngày {new Date(doc.pubDate).toLocaleDateString()}</p>
+      <p>Đăng ngày {formatDate(doc.pubDate)}</p>
       <p className="justify">
         {excerpt(minimumStringLength(doc.contentSnippet, 5), 50)}
       </p>

--- a/utils/date.test.js
+++ b/utils/date.test.js
@@ -3,29 +3,29 @@ import { formatDate } from './date';
 describe('formatDate', () => {
   it('Should works with locate string', () => {
     const input = '6/26/2021, 17:20:45';
-    const actual = formatDate(input);
-    const expected = '26/06/2021';
+    const actual = formatDate(input, 'vi-VN');
+    const expected = '26/6/2021';
     expect(actual).toEqual(expected);
   });
 
   it('Should works with timestamp', () => {
     const input = 1624702929549;
-    const actual = formatDate(input);
-    const expected = '26/06/2021';
+    const actual = formatDate(input, 'vi-VN');
+    const expected = '26/6/2021';
     expect(actual).toEqual(expected);
   });
 
   it('Should works with time string', () => {
     const input = 'Sat Jun 26 2021 17:23:19 GMT+0700 (Indochina Time)';
-    const actual = formatDate(input);
-    const expected = '26/06/2021';
+    const actual = formatDate(input, 'vi-VN');
+    const expected = '26/6/2021';
     expect(actual).toEqual(expected);
   });
 
   it('Should works with UTC/GMT string', () => {
     const input = 'Sat, 26 Jun 2021 13:44:18 GMT';
-    const actual = formatDate(input);
-    const expected = '26/06/2021';
+    const actual = formatDate(input, 'vi-VN');
+    const expected = '26/6/2021';
     expect(actual).toEqual(expected);
   });
 });

--- a/utils/date.test.js
+++ b/utils/date.test.js
@@ -21,4 +21,11 @@ describe('formatDate', () => {
     const expected = '26/06/2021';
     expect(actual).toEqual(expected);
   });
+
+  it('Should works with UTC/GMT string', () => {
+    const input = 'Sat, 26 Jun 2021 13:44:18 GMT';
+    const actual = formatDate(input);
+    const expected = '26/06/2021';
+    expect(actual).toEqual(expected);
+  });
 });

--- a/utils/date.test.js
+++ b/utils/date.test.js
@@ -1,0 +1,24 @@
+import { formatDate } from './date';
+
+describe('formatDate', () => {
+  it('Should works with locate string', () => {
+    const input = '6/26/2021, 17:20:45';
+    const actual = formatDate(input);
+    const expected = '26/06/2021';
+    expect(actual).toEqual(expected);
+  });
+
+  it('Should works with timestamp', () => {
+    const input = 1624702929549;
+    const actual = formatDate(input);
+    const expected = '26/06/2021';
+    expect(actual).toEqual(expected);
+  });
+
+  it('Should works with time string', () => {
+    const input = 'Sat Jun 26 2021 17:23:19 GMT+0700 (Indochina Time)';
+    const actual = formatDate(input);
+    const expected = '26/06/2021';
+    expect(actual).toEqual(expected);
+  });
+});

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -1,2 +1,5 @@
-export const formatDate = (date: string | number | Date) =>
-  new Intl.DateTimeFormat('en-GB').format(new Date(date));
+export const formatDate = (
+  date: string | number | Date,
+  locate: string | string[] = [],
+  options: Intl.DateTimeFormatOptions = {}
+) => new Intl.DateTimeFormat(locate, options).format(new Date(date));

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -1,0 +1,2 @@
+export const formatDate = (date: string) =>
+  new Intl.DateTimeFormat('en-GB').format(new Date(date));

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -1,2 +1,2 @@
-export const formatDate = (date: string) =>
+export const formatDate = (date: string | number | Date) =>
   new Intl.DateTimeFormat('en-GB').format(new Date(date));


### PR DESCRIPTION
Changed in this MR:
- Added date format util
- Format date to day/month/year instead of month/day/year (Vietnamese friendly)

What is `en-GB`? That **British English**, uses day-month-year order.