### PR TITLE
Fix table color in dark mode

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -33,6 +33,21 @@ body {
   background-color: var(--gray-6);
 }
 
+.dark .github-theme table td,
+.dark .github-theme table th {
+  padding: 6px 13px;
+  border: 1px solid #dfe2e522;
+}
+
+.dark .github-theme table tr {
+  background-color: #ffffff22;
+  border-top: 1px solid #c6cbd122;
+}
+
+.dark .github-theme table tr:nth-child(2n) {
+  background-color: #f6f8fa22;
+}
+
 a {
   color: inherit;
   text-decoration: none;


### PR DESCRIPTION
Table in dark mode has wrong color

Before:
![0542EF7B-52B8-43D6-B8F8-F326ECE5A0FA](https://user-images.githubusercontent.com/613943/131265741-baf5d409-d7b4-417e-8c25-869f2bb0ef04.jpeg)

After:
![EFAD361B-1A76-461D-8E09-237F9F93A8B4](https://user-images.githubusercontent.com/613943/131265742-d285ad23-a1a1-4162-b44a-cdcca18c4260.jpeg)
