### PR TITLE
Remove xluffy.github.io

### DIFF
--- a/channels.json
+++ b/channels.json
@@ -31,11 +31,6 @@
       "url": "https://beautyoncode.com/feed/"
     },
     {
-      "name": "Quăng",
-      "avatar_url": "",
-      "url": "https://xluffy.github.io/index.xml"
-    },
-    {
       "name": "Tu Huynh",
       "avatar_url": "tuhuynh.jpg",
       "url": "https://tuhuynh.com/rss.xml"


### PR DESCRIPTION
I have the same request with PR https://github.com/webuild-community/federated-blog/pull/96. Besides, I have some posts, not about tech, and I don't want to be popular them. So please remove my blog. Thanks