### PR TITLE
Do not reload the whole app when navigating between pages

### DIFF
--- a/components/Entry/index.tsx
+++ b/components/Entry/index.tsx
@@ -28,7 +28,7 @@ export const EntryAuthor = ({ author }: EntryAuthorProps) => {
         />
       </div>
       <div className="info">
-        <Link href={`/author/${hostName}`} passHref>
+        <Link href={`/author/${hostName}`}>
           <a>
             <b>{name}</b>
           </a>
@@ -53,13 +53,17 @@ export const Entry = ({ doc, showAuthor = true }: EntryProps) => {
     <RoundedPanel>
       {showAuthor && <EntryAuthor author={doc.author} />}
       <h3 className="entry-title mt-0">
-        <a href={`/read/${encodedUrl}`}>{doc.title}</a>
+        <Link href={`/read/${encodedUrl}`}>
+          <a>{doc.title}</a>
+        </Link>
       </h3>
       <p>Đăng ngày {formatDate(doc.pubDate as string)}</p>
       <p>{excerpt(minimumStringLength(doc.contentSnippet, 5), 50)}</p>
       <div className={styles.readMoreArea}>
-        <Link href={`/read/${encodedUrl}`} passHref>
-          <Button highlight>Đọc tiếp</Button>
+        <Link href={`/read/${encodedUrl}`}>
+          <a>
+            <Button highlight>Đọc tiếp</Button>
+          </a>
         </Link>
         <Button iconRight icon={externalLink} href={doc.link} target="_blank">
           Đọc trên blog của tác giả

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -21,14 +21,16 @@ const Header = () => {
   return (
     <header className={styles.header}>
       <div className={styles.headerContent}>
-        <Link href="/" passHref>
+        <Link href="/page/1">
           <a>
             <Logo />
           </a>
         </Link>
         <div className={styles.headerNav}>
-          <Link href="/page/random" passHref>
-            <Button>Đọc ngẫu nhiên</Button>
+          <Link href="/page/random">
+            <a>
+              <Button>Đọc ngẫu nhiên</Button>
+            </a>
           </Link>
           <Button
             onClick={onToggleTheme}

--- a/components/NotFoundPage/index.tsx
+++ b/components/NotFoundPage/index.tsx
@@ -9,7 +9,11 @@ export default function NotFoundPage() {
       <p className={styles.paragraph}>
         <strong>Trang này không tồn tại</strong>
         <br />
-        Nhấn <Link href="/">vào đây</Link> để quay lại trang chủ
+        Nhấn{' '}
+        <Link href="/page/1">
+          <a>vào đây</a>
+        </Link>{' '}
+        để quay lại trang chủ
       </p>
     </Layout>
   );

--- a/pages/author/[host].tsx
+++ b/pages/author/[host].tsx
@@ -78,12 +78,12 @@ const AuthorPage = ({ docs, author }: HomeProps) => {
         </div>
         <h2 className={styles.bigAssProfile_Name}>{author.name}</h2>
         <div className={styles.profileDetails}>
-          <Link href={blogLink} passHref>
+          <Link href={blogLink}>
             <a className={styles.profileLink}>
               <Icon component={HiOutlineLink} /> {getHostName(author.url)}
             </a>
           </Link>
-          <Link href={author.url} passHref>
+          <Link href={author.url}>
             <a className={styles.profileLink}>
               <Icon component={HiOutlineRss} /> {rssLinkDisplay}
             </a>


### PR DESCRIPTION
## Fixes
- [x] Do not reload app when navigating between pages
  - Do not need `passHref` when the direct child is `a`.
  - If the direct child of `<Link />` component is not `<a>`, even though we pass `passHref`, it still triggers a full page reload
  - There is no route such as `/`, so clicking on the logo triggers the full page reload. Workaround by changing `/` => `/page/1` (same for 404 page). I think the correct way to fix this is we need to have `/` route, then redirect to `/page/1`. But I'm not very familiar with that and we can leave it in the upcoming PR.

Reference: https://nextjs.org/docs/api-reference/next/link