### PR TITLE
fix: Fix some posts get 404 since there is a "/" in base64 encoded url

### DIFF
--- a/utils/url.ts
+++ b/utils/url.ts
@@ -13,13 +13,13 @@ export const getHostName = (url: string): string => {
 
 export const encodePostUrl = (url: string, author: number) => {
   const buffer = author.toString() + '|' + url.replace(/https?:\/\//, '');
-  return base64.encode(buffer);
+  return encodeURIComponent(base64.encode(buffer));
 };
 
 export const decodePostUrl = (
   buffer: string
 ): { author: number; url: string } => {
-  const decoded = base64.decode(buffer);
+  const decoded = base64.decode(decodeURIComponent(buffer));
   const match = decoded.match(/(\d+)\|(.*)/) ?? [];
   if (match.length > 2) {
     const author = +match[1];


### PR DESCRIPTION
## Fixes
- [x] Fix some posts that get 404 since there is a "/" in the URL. Encoded base64 has "/" character makes Nextjs routing confused.

## Reproduction

- This post results in 404 since it has a `/` in the URL: https://read.webuild.community/read/MTd8YmV0dGVycHJvZ3JhbW1pbmcucHViL2h0dHAtMi1hbmQtZ3JwYy10aGUtZGUtZmFjdG8tZm9yLW1pY3Jvc2VydmljZXMtY29tbXVuaWNhdGlvbi04NGE2YmIyYTYxMjY/c291cmNlPXJzcy1iZDk3YTA2ZTdkNmMtLS0tLS0y
- But this article should have link like this https://read.webuild.community/read/MTd8YmV0dGVycHJvZ3JhbW1pbmcucHViL2h0dHAtMi1hbmQtZ3JwYy10aGUtZGUtZmFjdG8tZm9yLW1pY3Jvc2VydmljZXMtY29tbXVuaWNhdGlvbi04NGE2YmIyYTYxMjY%2Fc291cmNlPXJzcy1iZDk3YTA2ZTdkNmMtLS0tLS0y